### PR TITLE
Support Added for Libgit2 v1.8

### DIFF
--- a/libgit2-glib/ggit-clone-options.c
+++ b/libgit2-glib/ggit-clone-options.c
@@ -149,7 +149,7 @@ create_repository_wrapper (git_repository **out,
 
 	if (error != NULL)
 	{
-#if LIBGIT2_VER_MAJOR > 0 || (LIBGIT2_VER_MAJOR == 0 && LIBGIT2_VER_MINOR >= 28)
+#if (LIBGIT2_VER_MAJOR > 0 && LIBGIT2_VER_MINOR < 8) || (LIBGIT2_VER_MAJOR == 0 && LIBGIT2_VER_MINOR >= 28)
 		git_error_set_str (GIT_ERROR, error->message);
 #else
 		giterr_set_str (GIT_ERROR, error->message);
@@ -191,7 +191,7 @@ create_remote_wrapper (git_remote     **out,
 
 	if (error)
 	{
-#if LIBGIT2_VER_MAJOR > 0 || (LIBGIT2_VER_MAJOR == 0 && LIBGIT2_VER_MINOR >= 28)
+#if (LIBGIT2_VER_MAJOR > 0 && LIBGIT2_VER_MINOR < 8) || (LIBGIT2_VER_MAJOR == 0 && LIBGIT2_VER_MINOR >= 28)
 		git_error_set_str (GIT_ERROR, error->message);
 #else
 		giterr_set_str (GIT_ERROR, error->message);

--- a/libgit2-glib/ggit-remote-callbacks.c
+++ b/libgit2-glib/ggit-remote-callbacks.c
@@ -160,7 +160,7 @@ credentials_wrap (git_cred     **cred,
 		{
 			if (error)
 			{
-#if LIBGIT2_VER_MAJOR > 0 || (LIBGIT2_VER_MAJOR == 0 && LIBGIT2_VER_MINOR >= 28)
+#if (LIBGIT2_VER_MAJOR > 0 && LIBGIT2_VER_MINOR < 8) || (LIBGIT2_VER_MAJOR == 0 && LIBGIT2_VER_MINOR >= 28)
 				git_error_set_str (GIT_ERROR, error->message);
 #else
 				giterr_set_str (GIT_ERROR, error->message);

--- a/libgit2-glib/ggit-types.h
+++ b/libgit2-glib/ggit-types.h
@@ -355,7 +355,7 @@ typedef enum
 	GGIT_CONFIG_LEVEL_XDG         = 3,
 	GGIT_CONFIG_LEVEL_GLOBAL      = 4,
 	GGIT_CONFIG_LEVEL_LOCAL       = 5,
-	GGIT_CONFIG_LEVEL_APP         = 6,
+	GGIT_CONFIG_LEVEL_APP         = 7,
 	GGIT_CONFIG_LEVEL_HIGHEST     = -1
 } GgitConfigLevel;
 


### PR DESCRIPTION
I build a flatpak app using both v1.2.0 and the master version of this library with libgit2 v1.8.1 (Released I think on Feb 2024) which has the support for openssh direct execution for ssh transactions. But it has some problems with that version, so I manually rectified all problems that causes the build to fail. 

The key point to be considered is I am not a pro developer, I just configured or readjusted the code according to my need and to make it compatible with new version of libgit2. **All changes are changed without considering what was the purpose of the previous code or previous state.** So review carefully what changes are made on the code by me and if anything causes any issues, please revoke this request and please let me know what was causing for a revoke.

Code is working perfectly for me. No errors no crashes. I am using the code for pushing, pulling, commiting, clonning all via ssh. So I have no way of knowing the errors on other operations.

IF NO ISSUES, CONSIDER THIS REQUEST.
If has issues please make a new version which is compatible for v1.8 by you guys.

My Changes:
- `git_error_set_str()` Function doesn't exist in v1.8 so replaced the condition on that from `#if LIBGIT2_VER_MAJOR > 0 || (LIBGIT2_VER_MAJOR == 0 && LIBGIT2_VER_MINOR >= 28)` to `#if (LIBGIT2_VER_MAJOR > 0 && LIBGIT2_VER_MINOR < 8) || (LIBGIT2_VER_MAJOR == 0 && LIBGIT2_VER_MINOR >= 28)`
- Changed the value of `GGIT_CONFIG_LEVEL_APP` from `6` to `7`, because the libgit2 v1.8 has that value, which causes an assertion on compiling.